### PR TITLE
Adding the option for the require.js path to be in the config

### DIFF
--- a/Configuration/ConfigurationBuilder.php
+++ b/Configuration/ConfigurationBuilder.php
@@ -3,22 +3,22 @@
 /**
  * Copyright (c) 2011 Hearsay News Products, Inc.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights 
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
- * copies of the Software, and to permit persons to whom the Software is 
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in 
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
 
@@ -50,7 +50,11 @@ class ConfigurationBuilder
      * @var array
      */
     protected $additionalConfig = array();
-    
+    /**
+     * @var string
+     */
+    protected $requirejsSrc = null;
+
     /**
      * Standard constructor.
      * @param TranslatorInterface $translator For getting the current locale.
@@ -84,7 +88,23 @@ class ConfigurationBuilder
     {
         $this->additionalConfig[$option] = $value;
     }
-    
+
+    /**
+     * Set the path to the main require.js script
+     * @param string $path the URI
+     */
+    public function setRequirejsSrc($path) {
+        $this->requirejsSrc = $path;
+    }
+
+    /**
+     * Get the path to the require.js script
+     * @return string
+     */
+    public function getRequirejsSrc() {
+        return $this->requirejsSrc;
+    }
+
     /**
      * Get the RequireJS configuration options.
      * @return array
@@ -99,6 +119,6 @@ class ConfigurationBuilder
             $config['paths'] = $this->paths;
         }
         return array_merge($config, $this->additionalConfig);
-    }    
+    }
 
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,22 +3,22 @@
 /**
  * Copyright (c) 2011 Hearsay News Products, Inc.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights 
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
- * copies of the Software, and to permit persons to whom the Software is 
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in 
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
 
@@ -49,6 +49,9 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('base_directory')
                         ->cannotBeEmpty()
                         ->isRequired()
+                    ->end()
+                    ->scalarNode('requirejs_src')
+                        ->defaultValue('')
                     ->end()
                     ->scalarNode('initialize_template')
                         ->cannotBeEmpty()

--- a/DependencyInjection/HearsayRequireJSExtension.php
+++ b/DependencyInjection/HearsayRequireJSExtension.php
@@ -3,22 +3,22 @@
 /**
  * Copyright (c) 2011 Hearsay News Products, Inc.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights 
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
- * copies of the Software, and to permit persons to whom the Software is 
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in 
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
 
@@ -53,6 +53,10 @@ class HearsayRequireJSExtension extends Extension
 
         $container->setParameter('hearsay_require_js.initialize_template', $config['initialize_template']);
 
+        //add the path to the require.js script
+        $configBuilder = $container->getDefinition('hearsay_require_js.configuration_builder');
+        $configBuilder->addMethodCall('setRequirejsSrc', array($config['requirejs_src']));
+
         if (isset($config['optimizer'])) {
             // Set optimizer options
             $container->setParameter('hearsay_require_js.r.path', $this->getRealPath($config['optimizer']['path'], $container));
@@ -86,7 +90,7 @@ class HearsayRequireJSExtension extends Extension
      * Configure a mapping from a filesystem path to a RequireJS namespace.
      * @param string $location
      * @param string $path
-     * @param ContainerBuilder $container 
+     * @param ContainerBuilder $container
      */
     protected function addNamespaceMapping($location, $path, ContainerBuilder $container)
     {
@@ -129,7 +133,7 @@ class HearsayRequireJSExtension extends Extension
      * Helper to convert bundle-notation paths to filesystem paths.
      * @param string $path
      * @param ContainerBuilder $container
-     * @return string 
+     * @return string
      */
     private function getRealPath($path, ContainerBuilder $container)
     {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,27 +1,28 @@
 ##
 # Copyright (c) 2011 Hearsay News Products, Inc.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights 
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-# copies of the Software, and to permit persons to whom the Software is 
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in 
+# The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
 parameters:
     hearsay_require_js.base_url: js
-    hearsay_require_js.base_directory: null # Set in the extension code 
+    hearsay_require_js.requirejs_src: null # Set in the extension code
+    hearsay_require_js.base_directory: null # Set in the extension code
     hearsay_require_js.initialize_template: null # Set in the extension code
     hearsay_require_js.r.path: null # Set in the extension code
 
@@ -35,18 +36,18 @@ services:
             - '@hearsay_require_js.namespace_mapping'
         tags:
             - { name: assetic.formula_loader, alias: require_js }
-            
+
     # Parent definition for module directory resources
     hearsay_require_js.directory_filename_resource:
         abstract: true
         class: Hearsay\RequireJSBundle\Factory\Resource\DirectoryFilenameResource
-            
+
     hearsay_require_js.namespace_mapping:
         public: false
         class: Hearsay\RequireJSBundle\Configuration\NamespaceMapping
         arguments:
             - %hearsay_require_js.base_url%
-        
+
     # Templating
     hearsay_require_js.configuration_builder:
         public: false
@@ -54,7 +55,7 @@ services:
         arguments:
             - '@translator'
             - %hearsay_require_js.base_url%
-    
+
     hearsay_require_js.helper:
         class: Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper
         arguments:
@@ -63,7 +64,7 @@ services:
             - %hearsay_require_js.initialize_template%
         tags:
             - { name: templating.helper }
-            
+
     hearsay_require_js.twig_extension:
         class: Hearsay\RequireJSBundle\Twig\Extension\RequireJSExtension
         arguments:
@@ -71,7 +72,7 @@ services:
             - '@hearsay_require_js.configuration_builder'
         tags:
             - { name: twig.extension }
-            
+
     # Assetic
     hearsay_require_js.optimizer_filter:
         class: Hearsay\RequireJSBundle\Filter\RequireJSOptimizerFilter
@@ -81,4 +82,4 @@ services:
             - %hearsay_require_js.base_directory%
         tags:
             - { name: assetic.filter, alias: requirejs }
-            
+

--- a/Resources/views/initialize.html.twig
+++ b/Resources/views/initialize.html.twig
@@ -1,22 +1,22 @@
 {#
  # Copyright (c) 2011 Hearsay News Products, Inc.
  #
- # Permission is hereby granted, free of charge, to any person obtaining a copy 
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal
- # in the Software without restriction, including without limitation the rights 
- # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
- # copies of the Software, and to permit persons to whom the Software is 
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
  # furnished to do so, subject to the following conditions:
  #
- # The above copyright notice and this permission notice shall be included in 
+ # The above copyright notice and this permission notice shall be included in
  # all copies or substantial portions of the Software.
  #
- # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
- # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
- # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  # SOFTWARE.
  #}
 {% spaceless %}
@@ -36,7 +36,7 @@
 
 {% block requirejs %}
     {# Applications may override the requirejs_src block to use a custom URL. #}
-    <script type='text/javascript'{% if main is defined and main is not empty %} data-main='{{ main }}'{% endif %} src='{% block requirejs_src '//cdnjs.cloudflare.com/ajax/libs/require.js/1.0.5/require.min.js' %}'></script>
+    <script type='text/javascript'{% if main is defined and main is not empty %} data-main='{{ main }}'{% endif %} src='{{  requirejs_src|default('//cdnjs.cloudflare.com/ajax/libs/require.js/1.0.5/require.min.js') }}'></script>
 {% endblock requirejs %}
 
 {% endspaceless %}

--- a/Templating/Helper/RequireJSHelper.php
+++ b/Templating/Helper/RequireJSHelper.php
@@ -3,22 +3,22 @@
 /**
  * Copyright (c) 2011 Hearsay News Products, Inc.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights 
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
- * copies of the Software, and to permit persons to whom the Software is 
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in 
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
 
@@ -89,6 +89,7 @@ class RequireJSHelper extends Helper
         return $this->engine->render($this->initializeTemplate, array(
             'config' => $options['configure'] ? $this->configurationBuilder->getConfiguration() : null,
             'main' => $options['main'],
+            'requirejs_src' => $this->configurationBuilder->getRequirejsSrc(),
         ));
     }
 


### PR DESCRIPTION
I'm new to Symfony2, so I may have missed something obvious. And if so, I'd love to be corrected :-)

The only real effect of this code change, other than slightly greater complexity, is that I had to alter the initialization template to print the uri via a 
```{{ requirejs_src|default('...') }} 

``````
rather than a 
```{% block requirejs_src '...' %} 
``````

as I couldn't find a good way to override the block from a config setting without having to duplicate the code along in the templates.

Why?  It feels more natural to me to have the require.js path in the same area as it's namespaces rather than in a template (the initialize template, or the template where they are overriding the block).

Also, I never could figure out how to override that block (see aforementioned newness to S2).
