### PR TITLE
Upgrade to Symfony 2.1

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -86,7 +86,6 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')->end()
                             ->end()
                             ->arrayNode('options')
-                                ->addDefaultsIfNotSet()
                                 ->defaultValue(array())
                                 ->useAttributeAsKey('name')
                                 ->prototype('array')

--- a/Filter/RequireJSOptimizerFilter.php
+++ b/Filter/RequireJSOptimizerFilter.php
@@ -3,22 +3,22 @@
 /**
  * Copyright (c) 2011 Hearsay News Products, Inc.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights 
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
- * copies of the Software, and to permit persons to whom the Software is 
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in 
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
 
@@ -26,7 +26,7 @@ namespace Hearsay\RequireJSBundle\Filter;
 
 use Assetic\Asset\AssetInterface;
 use Assetic\Filter\FilterInterface;
-use Assetic\Util\ProcessBuilder;
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Assetic filter for RequireJS optimization.
@@ -34,7 +34,6 @@ use Assetic\Util\ProcessBuilder;
  */
 class RequireJSOptimizerFilter implements FilterInterface
 {
-
     /**
      * Absolute path to node.js.
      * @var string
@@ -46,7 +45,7 @@ class RequireJSOptimizerFilter implements FilterInterface
      */
     protected $rPath = null;
     /**
-     * Base URL option to the optimizer (named for consistency with the r.js 
+     * Base URL option to the optimizer (named for consistency with the r.js
      * API; note this is generally actually a filesystem path).
      * @var string
      */
@@ -160,7 +159,7 @@ class RequireJSOptimizerFilter implements FilterInterface
         foreach ($this->excludes as $exclude) {
             $excludesString .= $exclude . ',';
         }
-        
+
         $pb->add('exclude=' . $excludesString);
 
         // Additional options

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/config": "2.0.*",
-        "symfony/dependency-injection": "2.0.*",
-        "symfony/finder": "2.0.*",
-        "symfony/templating": "2.0.*",
-        "symfony/yaml": "2.0.*",
-        "symfony/assetic-bundle": "2.0.*"
+        "symfony/config": "2.1.*",
+        "symfony/dependency-injection": "2.1.*",
+        "symfony/finder": "2.1.*",
+        "symfony/templating": "2.1.*",
+        "symfony/yaml": "2.1.*",
+        "symfony/assetic-bundle": "dev-master"
     },
     "autoload": {
         "psr-0": {"Hearsay\\RequireJSBundle": ""}


### PR DESCRIPTION
These changes were necessary to get the bundle to work with symfony 2.1. If you want to maintain a 2.0 version you could perhaps branch off a `2.0` branch and make `master` the 2.1 branch.

Tests are passing.

BTW: do you really need all those dependencies? If they are dev dependencies, please use [`require-dev`](http://getcomposer.org/doc/04-schema.md#package-links).
