### PR TITLE
Support RequireJS 2.0 insertRequire

### DIFF
--- a/Filter/RequireJSOptimizerFilter.php
+++ b/Filter/RequireJSOptimizerFilter.php
@@ -173,6 +173,10 @@ class RequireJSOptimizerFilter implements FilterInterface
 
         // Additional options
         foreach ($this->options as $option => $value) {
+            if ($option == 'insertRequire')
+            {
+              $value = $name;
+            }
             $pb->add($option . '=' . $value);
         }
 


### PR DESCRIPTION
The new version of RequireJS doesn't evaluate modules until they're require()'d [1]. With the way this bundle generates a hash for the module name it breaks when you use RequireJS 2.0.

I'm using data-main to point to my module's name which works in dev, but when I optimize for production the name is changed from "time/main" to "1441772dab8a4acdfab0c5314acc2fdc". Without the code in the commit the optimized file never executes the main module.

[1] https://github.com/jrburke/requirejs/wiki/Upgrading-to-RequireJS-2.0#wiki-delayed
