### PR TITLE
Added a build profile configuration option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,22 +3,22 @@
 /**
  * Copyright (c) 2011 Hearsay News Products, Inc.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights 
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
- * copies of the Software, and to permit persons to whom the Software is 
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in 
+ * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
 
@@ -77,6 +77,9 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('path')
                                 ->cannotBeEmpty()
                                 ->isRequired()
+                            ->end()
+                            ->scalarNode('build_profile')
+                                ->defaultNull()
                             ->end()
                             ->booleanNode('hide_unoptimized_assets')
                                 ->defaultFalse()

--- a/DependencyInjection/HearsayRequireJSExtension.php
+++ b/DependencyInjection/HearsayRequireJSExtension.php
@@ -62,13 +62,18 @@ class HearsayRequireJSExtension extends Extension
 
             // Set optimizer options
             $container->setParameter('hearsay_require_js.r.path', $this->getRealPath($config['optimizer']['path'], $container));
+            $filter = $container->getDefinition('hearsay_require_js.optimizer_filter');
+
+            if (isset($config['optimizer']['build_profile'])) {
+                $buildProfile = $this->getRealPath($config['optimizer']['build_profile'], $container);
+                $filter->addMethodCall('setBuildProfile', array($buildProfile));
+            }
             foreach ($config['optimizer']['excludes'] as $exclude) {
-                $filter = $container->getDefinition('hearsay_require_js.optimizer_filter');
                 $filter->addMethodCall('addExclude', array($exclude));
             }
             foreach ($config['optimizer']['options'] as $name => $settings) {
                 $value = $settings['value'];
-                $container->getDefinition('hearsay_require_js.optimizer_filter')->addMethodCall('setOption', array($name, $value));
+                $filter->addMethodCall('setOption', array($name, $value));
             }
         } else {
             // If the optimizer config isn't provided, don't provide the filter

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -23,7 +23,7 @@ To install the bundle manually:
         ));
 
   3. Add the bundle to your kernel::
-        
+
         // app/AppKernel.php
         public function registerBundles()
         {
@@ -38,7 +38,7 @@ Configuration
 =============
 
 You can expose directories of Javascript modules for access via ``require``.
-You must expose one root directory (from which files will be ``require``'d by 
+You must expose one root directory (from which files will be ``require``'d by
 default), and you may expose as many additional namespaces as you like.  Given a
 directory structure like::
 
@@ -128,7 +128,7 @@ Optimization
 ============
 
 The bundle provides an Assetic filter to create minified Javascript files using
-the RequireJS optimizer.  This also inlines any module definitions required by 
+the RequireJS optimizer.  This also inlines any module definitions required by
 the file being optimized.  You need to provide a path to the r.js optimizer in
 your configuration to use the filter::
 
@@ -150,9 +150,20 @@ Note that your configured path definitions will be incorporated into the
 optimizer filter, including the exclusion of external dependencies from the
 built file.
 
+If you wish to provide configuration using a `build profile <http://github.com/jrburke/r.js/blob/master/build/example.build.js>`_::
+
+        # app/config/config.yml
+        hearsay_require_js:
+            optimizer:
+                path: /path/to/r.js
+                build_profile: /path/to/app.build.js # Build profile location (filename is arbitrary)
+                options: { skipModuleInsertion: true } # Additional options to pass to the optimizer (optional)
+
+Note that any command line options will take precedence over matching corresponding build profile configuration.
+
 If you wish to prevent unoptimized assets from being served (in e.g. a
 production environment), you can suppress them::
-        
+
         # app/config/config.yml
         hearsay_require_js:
             optimizer:
@@ -162,5 +173,5 @@ production environment), you can suppress them::
 If you're doing this, be sure that all the modules you need are bundled into
 your optimized assets (i.e. you're not accessing any modules by dynamic name, or
 if you are, then you're explicitly including those modules via optimizer
-options) - otherwise, you may see certain assets available in development, but 
+options) - otherwise, you may see certain assets available in development, but
 not production.

--- a/Tests/DependencyInjection/HearsayRequireJSExtensionTest.php
+++ b/Tests/DependencyInjection/HearsayRequireJSExtensionTest.php
@@ -68,7 +68,7 @@ class HearsayRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
         // Check the namespace mapping
         $mapping = $container->getDefinition('hearsay_require_js.namespace_mapping');
         $methods = $mapping->getMethodCalls();
-        
+
         $this->assertEquals(3, count($methods), 'Incorrect number of method calls on namespace mapping');
         $this->assertContains(array(
             'registerNamespace', array($namespace_dir, 'namespace', true),
@@ -184,6 +184,28 @@ class HearsayRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($methods), 'Incorrect number of method calls on optimizer');
         $this->assertContains(array(
             'setOption', array('option', 'value'),
+        ), $methods, 'Did not find expected method call');
+    }
+
+    public function testOptimizerBuildProfileSet()
+    {
+        $config = array(
+            'base_directory' => '/home/user/base',
+            'optimizer' => array(
+                'path' => '/path/to/r.js',
+                'build_profile' => 'path/to/app.build.js'
+            ),
+        );
+        $container = $this->getContainerBuilder();
+        $loader = new HearsayRequireJSExtension();
+
+        $loader->load(array($config), $container);
+
+        $optimizer = $container->getDefinition('hearsay_require_js.optimizer_filter');
+        $methods = $optimizer->getMethodCalls();
+        $this->assertEquals(1, count($methods), 'Incorrect number of method calls on optimizer');
+        $this->assertContains(array(
+            'setBuildProfile', array('path/to/app.build.js'),
         ), $methods, 'Did not find expected method call');
     }
 


### PR DESCRIPTION
Hi,

I've added a way to provide a path to a build profile for the optimizer, which is necessary as I have configuration that can't be set in the YAML file as it's invalid YAML. Any chance you could add this functionality, as I can't optimize my project without it?

Just noticed when making the PR that my IDE's tidied redundant whitespace in the files I edited - let me know if that's a problem and I'll redo the commits.

Cheers,
Craig
