### PR TITLE
output module assets as .js

### DIFF
--- a/Configuration/NamespaceMapping.php
+++ b/Configuration/NamespaceMapping.php
@@ -71,7 +71,8 @@ class NamespaceMapping implements NamespaceMappingInterface
         foreach ($this->namespaces as $path => $settings) {
             if (strpos($filename, $path) === 0) {
                 if ($settings['is_dir']) {
-                    return preg_replace('#[/\\\\]+#', '/', $this->basePath . '/' . $settings['namespace'] . '/' . substr($filename, strlen($path)));
+                    $basename = preg_replace('#\.[^.]+$#', '.js', substr($filename, strlen($path)));
+                    return preg_replace('#[/\\\\]+#', '/', $this->basePath . '/' . $settings['namespace'] . '/' . $basename);
                 }
 
                 return preg_replace('#[/\\\\]+#', '/', $this->basePath . '/' . $settings['namespace'] . '.' . pathinfo($filename, PATHINFO_EXTENSION));

--- a/Tests/Configuration/NamespaceMappingTest.php
+++ b/Tests/Configuration/NamespaceMappingTest.php
@@ -64,4 +64,11 @@ class NamespaceMappingTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($mapping->getModulePath(__DIR__ . '/dir/file.js'), 'Non-existent module expected not to be converted');
     }
 
+    public function testFilesRenamedToJs()
+    {
+        $mapping = new NamespaceMapping('js');
+        $mapping->registerNamespace(__DIR__ . '/dir', 'modules');
+
+        $this->assertEquals('js/modules/file2.js', $mapping->getModulePath(__DIR__ . '/dir/file2.coffee'), 'Incorrect file-to-module conversion');
+    }
 }


### PR DESCRIPTION
This changes the output path to use a `.js` extension. This allows to use the bundle with `.coffee` scripts.
