### PR TITLE
Add master branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
     "autoload": {
         "psr-0": {"Hearsay\\RequireJSBundle": ""}
     },
-    "target-dir": "Hearsay/RequireJSBundle"
+    "target-dir": "Hearsay/RequireJSBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a alias for the master branch - I've specified 1.1.x because I think it'd be good to also then take a 1.0.0 tag at this point to allow those including the bundle (including myself :-) ) to point to a stable version.
