### PR TITLE
Use AssetHelper to prefix the baseurl

### DIFF
--- a/Configuration/ConfigurationBuilder.php
+++ b/Configuration/ConfigurationBuilder.php
@@ -108,12 +108,14 @@ class ConfigurationBuilder
      */
     public function getConfiguration()
     {
-        $rootUrl = '';
-        if ($this->useControllerForAssets && $this->container->isScopeActive('request')) {
-            $rootUrl = $this->container->get('request')->getBaseUrl();
+        $baseUrl = $this->container->get('templating.helper.assets')->getUrl(\ltrim($this->baseUrl, '/'));
+        // remove ?version from end of URL
+        if (($p = strpos($baseUrl, '?')) !== false) {
+            $baseUrl = substr($baseUrl, 0, $p);
         }
+
         $config = array(
-            'baseUrl' => $rootUrl . '/' . \ltrim($this->baseUrl, '/'),
+            'baseUrl' => $baseUrl,
             'locale' => $this->translator->getLocale(),
         );
         if ($this->paths !== null) {


### PR DESCRIPTION
This ensures the requirejs baseurl setting respects the 'framework.templating.assets_base_urls' setting in the Symfony config.

Fixes hearsayit/HearsayRequireJSBundle#19

Enables scripts to be stored at a non-default path (e.g. not in the web root), and/or accessed via a different hostname (e.g. using a CDN).

See also: http://symfony.com/doc/2.1/reference/configuration/framework.html#assets-base-urls
