### PR TITLE
Command line arguments for optimizer cause double .js.js suffix

### DIFF
--- a/Filter/RequireJSOptimizerFilter.php
+++ b/Filter/RequireJSOptimizerFilter.php
@@ -226,9 +226,7 @@ class RequireJSOptimizerFilter implements FilterInterface
 
         // Additional options
         foreach ($this->options as $option => $value) {
-            /** XXX CUSTOM PREG_REPLACE CALL, DO PR OR FORK FOR THIS */
             $pb->add($option . '=' . preg_replace('#\.js$#', '', $value));
-            // $pb->add($option . '=' . $value);
         }
 
         $proc = $pb->getProcess();

--- a/Filter/RequireJSOptimizerFilter.php
+++ b/Filter/RequireJSOptimizerFilter.php
@@ -226,7 +226,9 @@ class RequireJSOptimizerFilter implements FilterInterface
 
         // Additional options
         foreach ($this->options as $option => $value) {
-            $pb->add($option . '=' . $value);
+            /** XXX CUSTOM PREG_REPLACE CALL, DO PR OR FORK FOR THIS */
+            $pb->add($option . '=' . preg_replace('#\.js$#', '', $value));
+            // $pb->add($option . '=' . $value);
         }
 
         $proc = $pb->getProcess();


### PR DESCRIPTION
I'm using your bundle with the following config:

```
# config.yml
hearsay_require_js:
    base_directory: "%kernel.root_dir%/Resources/scripts"
    require_js_src: '/js/Acme/lib/require.js'
    optimizer:
        path: '/usr/local/bin/r.js'
        build_profile: '%kernel.root_dir%/Resources/scripts/r.build.js'
        hide_unoptimized_assets: false
    paths:
        jquery:               '@AcmeBaseBundle/Resources/public/js/lib/jquery-1.9.1.min.js'
```

Which works fine in development mode, but when dumping assets with the --env=prod parameter, I get an error with the r.js optimizer:

```
[RuntimeException]
  Optimization failed:
  Tracing dependencies for: 54e2dda05b0e609b386de50cfeef0d63
  Error: ENOENT, no such file or directory '/var/www/acme/src/Acme/BaseBundle/Resources/public/js/lib/jquery-1.9.1.min.js.js'
  In module tree:
      54e2dda05b0e609b386de50cfeef0d63
        Acme/View/Frame/MessageDisplay
          Acme/Modal
```

This proposed one line fix solves the issue by replacing the last '.js' on all command line argument values. I've run the unit tests with success and tested this with dumping --env=dev and --env=prod, and also by running it with the assetic:use_controller:true setting in dev mode.
