### PR TITLE
Don't attempt to match in namespace if path is invalid

### DIFF
--- a/Configuration/NamespaceMapping.php
+++ b/Configuration/NamespaceMapping.php
@@ -76,6 +76,11 @@ class NamespaceMapping implements NamespaceMappingInterface
         }
 
         $filename = realpath($filename);
+
+        if (!$filename) {
+            return false;
+        }
+
         foreach ($this->namespaces as $path => $settings) {
             if (strpos($filename, $path) === 0) {
                 if ($settings['is_dir']) {
@@ -85,6 +90,7 @@ class NamespaceMapping implements NamespaceMappingInterface
                 return preg_replace('#[/\\\\]+#', '/', $this->basePath . '/' . $settings['namespace'] . '.' . pathinfo($filename, PATHINFO_EXTENSION));
             }
         }
+
         return false;
     }
 }

--- a/Tests/Configuration/NamespaceMappingTest.php
+++ b/Tests/Configuration/NamespaceMappingTest.php
@@ -64,4 +64,12 @@ class NamespaceMappingTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($mapping->getModulePath(__DIR__ . '/dir/file.js'), 'Non-existent module expected not to be converted');
     }
 
+    public function testNonexistentModulePathReturnsFalse()
+    {
+        $mapping = new NamespaceMapping('js');
+        $mapping->registerNamespace('dir', 'root');
+
+        $this->assertFalse($mapping->getModulePath(__DIR__ . 'foo'), 'Module path should not be found');
+    }
+
 }


### PR DESCRIPTION
https://github.com/hearsayit/HearsayRequireJSBundle/pull/30 introduced a bug which causes a warning `strpos(): Empty needle` when attempting to match a namespace for an invalid module path.
