### PR TITLE
Fixing issues with module names not being properly resolved in FilenamesResource

### DIFF
--- a/Factory/Resource/FilenamesResource.php
+++ b/Factory/Resource/FilenamesResource.php
@@ -95,6 +95,6 @@ class FilenamesResource implements ResourceInterface
      */
     private function getFilePath()
     {
-        return is_file($this->path) ? $this->path : $this->path . '.js';
+        return is_readable($this->path) ? $this->path : $this->path . '.js';
     }
 }

--- a/Factory/Resource/FilenamesResource.php
+++ b/Factory/Resource/FilenamesResource.php
@@ -54,7 +54,7 @@ class FilenamesResource implements ResourceInterface
      */
     public function getContent()
     {
-        $file = is_file($this->path) ? $this->path : $this->path . '.js';
+        $file = $this->getFilePath();
 
         if (is_file($file)) {
             return strtr($this->path, '\\', '/');
@@ -75,7 +75,9 @@ class FilenamesResource implements ResourceInterface
      */
     public function isFresh($timestamp)
     {
-        return filemtime($this->path) <= $timestamp;
+        $path = $this->getFilePath();
+
+        return filemtime($path) <= $timestamp;
     }
 
     /**
@@ -84,5 +86,15 @@ class FilenamesResource implements ResourceInterface
     public function __toString()
     {
         return strtr($this->path, '\\', '/');
+    }
+
+    /**
+     * Gets a resolved file path
+     *
+     * @return string
+     */
+    private function getFilePath()
+    {
+        return is_file($this->path) ? $this->path : $this->path . '.js';
     }
 }


### PR DESCRIPTION
I was experiencing issues in my travis build process (but not locally - even when following through the travis build process locally) with module names in my `paths` config not being resolved to file names.

For example:

`jquery: "@AcmeCoreBundle/Resources/public/js/vendor/jquery/jquery"`

was not being resolved correctly to the full file path in `isFresh()` in `Factory/Resource/FilenamesResource.php`.

I've updated the logic for this. There's also a fix in there for when a `path` value points to a directory and not a real file.
