### PR TITLE
Add start option and data-start script attribute to support additional approach to multi-page sites 

### DIFF
--- a/Resources/views/initialize.html.twig
+++ b/Resources/views/initialize.html.twig
@@ -36,7 +36,7 @@
 
 {% block require_js %}
     {# Applications may override the src block to use a custom URL. #}
-    <script type='text/javascript'{% if main is defined and main is not empty %} data-main='{{ main }}'{% endif %} src='{% block src require_js.src %}'></script>
+    <script type='text/javascript'{% if main is defined and main is not empty %} data-main='{{ main }}'{% endif %} {% if start is defined and start is not empty %} data-start='{{ start }}'{% endif %} src='{% block src require_js.src %}'></script>
 {% endblock require_js %}
 
 {% endspaceless %}

--- a/Templating/Helper/RequireJSHelper.php
+++ b/Templating/Helper/RequireJSHelper.php
@@ -83,12 +83,14 @@ class RequireJSHelper extends Helper
     {
         $defaults = array(
             'main' => null,
+            'start' => null,
             'configure' => true,
         );
         $options = array_merge($defaults, $options);
         return $this->engine->render($this->initializeTemplate, array(
             'config' => $options['configure'] ? $this->configurationBuilder->getConfiguration() : null,
             'main' => $options['main'],
+            'start' => $options['start'],
         ));
     }
 


### PR DESCRIPTION
So I can avoid wrapping all of my main modules in a require call to load a common js file I prefer to use this approach to have the main script look for a data-start attribute and require that module if available. In order to support this I had to add an extra option to the initialize method for the start script.

Alternately if the options were just passed through directly from the twig template to the initialize call then I could just override the initialization template, but since it only passed through main and config options I had to modify the helper. 

This stack overflow post discusses this approach to multi page requirejs: http://stackoverflow.com/questions/11674824/how-to-use-requirejs-build-profile-r-js-in-a-multi-page-project/11730147#11730147

Great bundle!
