### PR TITLE
Fix r.js build profile generation

### DIFF
--- a/Assetic/Filter/RJsFilter.php
+++ b/Assetic/Filter/RJsFilter.php
@@ -260,7 +260,7 @@ class RJsFilter extends BaseNodeFilter
 
         unset($shim);
 
-        $content->shim    = (object) $this->shim;
+        $content->shim    = (object) $this->shim[0];
         $content->exclude = $this->exclude;
 
         foreach ($this->options as $option => $value) {

--- a/Assetic/Filter/RJsFilter.php
+++ b/Assetic/Filter/RJsFilter.php
@@ -246,6 +246,10 @@ class RJsFilter extends BaseNodeFilter
         $content->paths->$name = $input;
 
         foreach ($this->paths as $path => $location) {
+            if(preg_match('/(.+)\.js/i', $location)) {
+                $location = substr($location, 0, strlen($location) - 3);
+            }
+            
             $content->paths->$path = $location;
         }
 


### PR DESCRIPTION
There are currently two bugs in the build profile generator. First, all path definitions have double file endings (file.js.js). Second, the shim definition is an array instead of an object. This pull request fixes both issues.
