### PR TITLE
fix loading of files other than *.js and *.coffee

### DIFF
--- a/Configuration/NamespaceMapping.php
+++ b/Configuration/NamespaceMapping.php
@@ -84,7 +84,7 @@ class NamespaceMapping implements NamespaceMappingInterface
 
                 if (is_dir($realPath) && $basename) {
                     // To allow to use the bundle with `.coffee` scripts
-                    $basename = preg_replace('#\.[^.]+$#', '.js', $basename);
+                    $basename = preg_replace('#\.coffee$#', '.js', $basename);
 
                     $modulePath .= '/' . $basename;
                 }


### PR DESCRIPTION
Currently you replace all file endings with .js. This breaks the routes for other files like template files loaded with the text plugin for RequireJs which may have a .html ending. Assetic is not able to properly generate routes for those files in development mode. You should only explicitly replace those file extensions that need replacement.
