### PR TITLE
require_js Twig global

### DIFF
--- a/Templating/Helper/RequireJSHelper.php
+++ b/Templating/Helper/RequireJSHelper.php
@@ -138,4 +138,14 @@ class RequireJSHelper extends Helper
 
         return $this->requireJsSrc;
     }
+
+    /**
+     * Gets the RequireJS configuration
+     *
+     * @return string Returns a string that represents the RequireJS configuration
+     */
+    public function config()
+    {
+        return $this->configurationBuilder->getConfiguration();
+    }
 }

--- a/Twig/Extension/RequireJSExtension.php
+++ b/Twig/Extension/RequireJSExtension.php
@@ -70,10 +70,7 @@ class RequireJSExtension extends \Twig_Extension
     public function getGlobals()
     {
         return array(
-            'require_js' => array(
-                'config' => $this->getHelper()->config(),
-                'src' => $this->getHelper()->src(),
-            ),
+            'require_js_config' => $this->getHelper()->config(),
         );
     }
 

--- a/Twig/Extension/RequireJSExtension.php
+++ b/Twig/Extension/RequireJSExtension.php
@@ -65,6 +65,19 @@ class RequireJSExtension extends \Twig_Extension
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getGlobals()
+    {
+        return array(
+            'require_js' => array(
+                'config' => $this->getHelper()->config(),
+                'src' => $this->getHelper()->src(),
+            ),
+        );
+    }
+
+    /**
      * {@inheritDoc}
      * @codeCoverageIgnore
      */


### PR DESCRIPTION
To close #49 

I've defined the variable with `getGlobals` as it was in 1.0.

I'm a little confused as to why `require_js_src` is defined as a Twig function rather than a global though, given it doesn't accept arguments.
Would you prefer a `require_js_config` function to be created to hold the configuration instead to be consistent?
