### PR TITLE
Addressed issue #44 regarding dev env 404 errors

### DIFF
--- a/Configuration/ConfigurationBuilder.php
+++ b/Configuration/ConfigurationBuilder.php
@@ -151,7 +151,7 @@ class ConfigurationBuilder
 
             if ($modulePath) {
                 $modulePath = preg_replace('~\.js$~', '', $modulePath);
-                $location = $this->getBaseUrl() . '/' . $modulePath;
+                $location = $this->getUrl($modulePath);
             }
         }
 
@@ -169,11 +169,13 @@ class ConfigurationBuilder
      *
      * @return string
      */
-    protected function getBaseUrl()
+    protected function getUrl($path = null)
     {
         if ($this->container->getParameter('assetic.use_controller')
             && $this->container->isScopeActive('request')) {
-            return $this->container->get('request')->getBaseUrl();
+            $request = $this->container->get('request');
+            if ($path && file_exists($path)) return $request->getBasePath() . '/' . $path;
+            return $request->getBaseUrl() . '/' . $path;
         }
 
         $baseUrl = $this->container->isScopeActive('templating.helper.assets')
@@ -185,7 +187,7 @@ class ConfigurationBuilder
             $baseUrl = substr($baseUrl, 0, $pos);
         }
 
-        return $baseUrl;
+        return $baseUrl . '/' . $path;
     }
 
     /**
@@ -195,6 +197,6 @@ class ConfigurationBuilder
      */
     protected function getScriptUrl()
     {
-        return $this->getBaseUrl() . '/' . $this->baseUrl;
+        return $this->getUrl($this->baseUrl);
     }
 }

--- a/DependencyInjection/HearsayRequireJSExtension.php
+++ b/DependencyInjection/HearsayRequireJSExtension.php
@@ -85,8 +85,8 @@ class HearsayRequireJSExtension extends Extension
             ->getDefinition('hearsay_require_js.configuration_builder');
 
         if ($container->getParameter('kernel.debug')) {
-            $args = isset($options['urlArgs']) ? $options['urlArgs'] : '';
-            $options['urlArgs'] = trim($args.'&v='.time(), '&');
+            $args = isset($config['options']['urlArgs']) ? $config['options']['urlArgs'] : '';
+            $config['options']['urlArgs'] = trim($args.'&v='.time(), '&');
         }
 
         foreach ($config['options'] as $option => $settings) {

--- a/DependencyInjection/HearsayRequireJSExtension.php
+++ b/DependencyInjection/HearsayRequireJSExtension.php
@@ -85,8 +85,8 @@ class HearsayRequireJSExtension extends Extension
             ->getDefinition('hearsay_require_js.configuration_builder');
 
         if ($container->getParameter('kernel.debug')) {
-            $args = isset($config['options']['urlArgs']) ? $config['options']['urlArgs'] : '';
-            $config['options']['urlArgs'] = trim($args.'&v='.time(), '&');
+            $args = isset($config['options']['urlArgs']) ? $config['options']['urlArgs']['value'] : '';
+            $config['options']['urlArgs'] = array('value' => trim($args.'&v='.time(), '&'));
         }
 
         foreach ($config['options'] as $option => $settings) {

--- a/DependencyInjection/HearsayRequireJSExtension.php
+++ b/DependencyInjection/HearsayRequireJSExtension.php
@@ -84,6 +84,11 @@ class HearsayRequireJSExtension extends Extension
         $configurationBuilder = $container
             ->getDefinition('hearsay_require_js.configuration_builder');
 
+        if ($container->getParameter('kernel.debug')) {
+            $args = isset($options['urlArgs']) ? $options['urlArgs'] : '';
+            $options['urlArgs'] = trim($args.'&v='.time(), '&');
+        }
+
         foreach ($config['options'] as $option => $settings) {
             $configurationBuilder->addMethodCall('addOption', array($option, $settings['value']));
         }


### PR DESCRIPTION
> [ConfigurationBuilder] Use `Request#getBasePath()` if desired target file exists, but fall back to `Request#getBaseUrl()` otherwise; that is, if the script needs to be generated by Assetic's controller.

If `assetic.use_controller` was enabled, ConfigurationBuilder unconditionally prepended the front controller script (i.e. `app_dev.php/`) to the base URL. This led to 404 errors when attempting to load, for example, `/base/path/app_dev.php/path/to/file.js` in a `require()` call. Scripts that are generated by Assetic need this behavior, but scripts that already exist in the `web` directory should be loaded directly without going through the Assetic controller.
