### PR TITLE
Support of Symfony bundles in paths

### DIFF
--- a/Assetic/Filter/RJsFilter.php
+++ b/Assetic/Filter/RJsFilter.php
@@ -307,7 +307,20 @@ class RJsFilter extends BaseNodeFilter
     protected function getModuleName(AssetInterface $asset)
     {
         $fullPath = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
-        $relPath  = str_replace($this->baseUrl . '/', '', $fullPath);
+
+        if (strpos($fullPath, $this->baseUrl) === 0) {
+            $relPath = str_replace($this->baseUrl . '/', '', $fullPath);
+        } else {
+            $suitablePath = '';
+            $suitablePathName = '';
+            foreach ($this->paths as $path => $location) {
+                if (strpos($fullPath, $location) === 0 && strlen($location) > strlen($suitablePath)) {
+                    $suitablePath = $location;
+                    $suitablePathName = $path;
+                }
+            }
+            $relPath = str_replace($suitablePath, $suitablePathName, $fullPath);
+        }
 
         return substr_replace($relPath, '', strpos($relPath, '.js'), 3);
     }

--- a/Assetic/Filter/RJsFilter.php
+++ b/Assetic/Filter/RJsFilter.php
@@ -313,12 +313,14 @@ class RJsFilter extends BaseNodeFilter
         } else {
             $suitablePath = '';
             $suitablePathName = '';
+            
             foreach ($this->paths as $path => $location) {
-                if (strpos($fullPath, $location) === 0 && strlen($location) > strlen($suitablePath)) {
+                if (strpos($fullPath, $location) === 0 && $location > $suitablePath) {
                     $suitablePath = $location;
                     $suitablePathName = $path;
                 }
             }
+            
             $relPath = str_replace($suitablePath, $suitablePathName, $fullPath);
         }
 


### PR DESCRIPTION
Some assets could not be in a place indicated in baseUrl. This should be taken into consideration while receiving module name from asset. If an original file is not in a place indicated in baseUrl, it means the path to the file can be found in 'paths'. That's where the name of the module can be taken of.
