### PR TITLE
Fix src() method in RequireJSHelper.php

### DIFF
--- a/Templating/Helper/RequireJSHelper.php
+++ b/Templating/Helper/RequireJSHelper.php
@@ -118,9 +118,13 @@ class RequireJSHelper extends Helper
      */
     public function src()
     {
-        if ($this->engine->supports($this->requireJsSrc)
-            && $this->engine->exists($this->requireJsSrc)) {
-            return $this->engine->render($this->requireJsSrc);
+        try {
+            if ($this->engine->supports($this->requireJsSrc)
+                && $this->engine->exists($this->requireJsSrc)) {
+                return $this->engine->render($this->requireJsSrc);
+            }
+        }
+        catch (\InvalidArgumentException $err) {
         }
 
         return $this->requireJsSrc;

--- a/Templating/Helper/RequireJSHelper.php
+++ b/Templating/Helper/RequireJSHelper.php
@@ -118,8 +118,8 @@ class RequireJSHelper extends Helper
      */
     public function src()
     {
-        if ($this->engine->exists($this->requireJsSrc)
-            && $this->engine->supports($this->requireJsSrc)) {
+        if ($this->engine->supports($this->requireJsSrc)
+            && $this->engine->exists($this->requireJsSrc)) {
             return $this->engine->render($this->requireJsSrc);
         }
 


### PR DESCRIPTION
First check if the engine supports the $this->requireJsSrc file, and only then check if it exists. Closes #71.
