### PR TITLE
Add helper alias in services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -49,7 +49,7 @@ services:
       - %hearsay_require_js.initialize_template%
       - %hearsay_require_js.require_js_src%
     tags:
-      - { name: templating.helper }
+      - { name: templating.helper, alias: require_js }
 
   hearsay_require_js.twig_extension:
     class: %hearsay_require_js.twig_extension.class%


### PR DESCRIPTION
It would be very useful to add a helper alias in services.yml so that RequireJSHelper can be used inside PHP templates like so:

```
/* @var Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper $requireJs */
$requireJs = $view['require_js'];
echo $requireJs->initialize();
```

Cheers!
