### PR TITLE
Remove deprecated calls Twig_Function_Method

### DIFF
--- a/Configuration/ConfigurationBuilder.php
+++ b/Configuration/ConfigurationBuilder.php
@@ -164,7 +164,7 @@ class ConfigurationBuilder
             $modulePath = $this->mapping->getModulePath($location);
 
             if ($modulePath !== null) {
-                $location = '/' . str_replace('.js', '', $modulePath);
+                $location = '/' . preg_replace('~\.js$~', '', $modulePath);
             }
         }
 

--- a/Configuration/ConfigurationBuilder.php
+++ b/Configuration/ConfigurationBuilder.php
@@ -157,6 +157,10 @@ class ConfigurationBuilder
         !is_array($locations) && $locations = (array) $locations;
 
         foreach ($locations as &$location) {
+            if (preg_match('~^(\/\/|http|https)~', $location)) {
+                continue;
+            }
+
             $modulePath = $this->mapping->getModulePath($location);
 
             if ($modulePath !== null) {


### PR DESCRIPTION
Please remove deprecated twig calls Twig_Function_Method in /Hearsay/RequireJSBundle/Twig/Extension/RequireJSExtension

``` php
public function getFunctions()
    {
        return array(
            'require_js_initialize' => new \Twig_Function_Method($this, 'renderInitialize', array('is_safe' => array('html'))),
        );
    }
```

should be replaced by:

``` php
public function getFunctions()
    {
        return array(
             new \Twig_SimpleFunction('require_js_initialize', array($this, 'renderInitialize'), array('is_safe' => array('html'))),
        );
```
