### PR TITLE
Resolve Symfony 3.4 deprecation warnings

### DIFF
--- a/Configuration/ConfigurationBuilder.php
+++ b/Configuration/ConfigurationBuilder.php
@@ -183,22 +183,22 @@ class ConfigurationBuilder
      */
     protected function getBaseUrl()
     {
-        $baseUrl = '';
-
-        if ($this->container->isScopeActive('request')) {
-            if ($this->container->getParameter('assetic.use_controller')) {
-                $baseUrl = $this->container->get('request')->getBaseUrl();
-            } else {
-                $baseUrl = $this->container->get('templating.helper.assets')->getUrl('');
-
-                // Remove ?version from the end of the base URL
-                if (($pos = strpos($baseUrl, '?')) !== false) {
-                    $baseUrl = substr($baseUrl, 0, $pos);
-                }
-            }
+        if (!$this->container->has('request_stack') ||
+            !$request = $this->container->get('request_stack')->getCurrentRequest()) {
+            return rtrim('', '/');
         }
 
-        // Remove trailing slash, if there is one
+        if ($this->container->getParameter('assetic.use_controller')) {
+            return rtrim($request->getBaseUrl(), '/');
+        }
+
+        $baseUrl = $this->container->get('templating.helper.assets')->getUrl('');
+
+        // Remove ?version from the end of the base URL
+        if (($pos = strpos($baseUrl, '?')) !== false) {
+            $baseUrl = substr($baseUrl, 0, $pos);
+        }
+
         return rtrim($baseUrl, '/');
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,7 +81,6 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                                 ->booleanNode('external')
-                                    ->cannotBeEmpty()
                                     ->defaultFalse()
                                 ->end()
                             ->end()

--- a/DependencyInjection/HearsayRequireJSExtension.php
+++ b/DependencyInjection/HearsayRequireJSExtension.php
@@ -12,7 +12,7 @@
 namespace Hearsay\RequireJSBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -148,7 +148,7 @@ class HearsayRequireJSExtension extends Extension
         }
 
         if ($generateAssets) {
-            $resource = new DefinitionDecorator('hearsay_require_js.filenames_resource');
+            $resource = new ChildDefinition('hearsay_require_js.filenames_resource');
             $resource->setArguments(array($location));
             $resource->addTag('assetic.formula_resource', array('loader' => 'require_js'));
             $container->addDefinitions(array(

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ help:
 
 test:
 	php vendor/bin/phpcs --standard=PSR2 --ignore=vendor/ --extensions=php . -n -p
-	wget https://raw.github.com/jrburke/r.js/2.1.8/dist/r.js -nc
+	curl -LO https://raw.github.com/jrburke/r.js/2.1.8/dist/r.js
 	php vendor/bin/phpunit --coverage-text

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,58 +15,58 @@ parameters:
 
 services:
   hearsay_require_js.module_formula_loader:
-    class: %hearsay_require_js.module_formula_loader.class%
+    class: '%hearsay_require_js.module_formula_loader.class%'
     arguments:
-      - @assetic.asset_factory
-      - @hearsay_require_js.namespace_mapping
+      - '@assetic.asset_factory'
+      - '@hearsay_require_js.namespace_mapping'
     tags:
       - { name: assetic.formula_loader, alias: require_js }
 
   hearsay_require_js.filenames_resource:
-    class: %hearsay_require_js.filenames_resource.class%
+    class: '%hearsay_require_js.filenames_resource.class%'
     abstract: true
 
   hearsay_require_js.namespace_mapping:
-    class: %hearsay_require_js.namespace_mapping.class%
+    class: '%hearsay_require_js.namespace_mapping.class%'
     arguments:
-      - %hearsay_require_js.base_url%
+      - '%hearsay_require_js.base_url%'
     public: false
 
   hearsay_require_js.configuration_builder:
-    class: %hearsay_require_js.configuration_builder.class%
+    class: '%hearsay_require_js.configuration_builder.class%'
     arguments:
-      - @service_container
-      - @hearsay_require_js.namespace_mapping
-      - %hearsay_require_js.base_url%
-      - %hearsay_require_js.shim%
+      - '@service_container'
+      - '@hearsay_require_js.namespace_mapping'
+      - '%hearsay_require_js.base_url%'
+      - '%hearsay_require_js.shim%'
     public: false
 
   hearsay_require_js.templating_helper:
-    class: %hearsay_require_js.templating_helper.class%
+    class: '%hearsay_require_js.templating_helper.class%'
     arguments:
-      - @templating
-      - @hearsay_require_js.configuration_builder
-      - %hearsay_require_js.initialize_template%
-      - %hearsay_require_js.require_js_src%
+      - '@templating'
+      - '@hearsay_require_js.configuration_builder'
+      - '%hearsay_require_js.initialize_template%'
+      - '%hearsay_require_js.require_js_src%'
     tags:
       - { name: templating.helper }
 
   hearsay_require_js.twig_extension:
-    class: %hearsay_require_js.twig_extension.class%
+    class: '%hearsay_require_js.twig_extension.class%'
     arguments:
-      - @service_container
-      - @hearsay_require_js.configuration_builder
+      - '@service_container'
+      - '@hearsay_require_js.configuration_builder'
     tags:
       - { name: twig.extension }
 
   hearsay_require_js.optimizer_filter:
-    class: %hearsay_require_js.optimizer_filter.class%
+    class: '%hearsay_require_js.optimizer_filter.class%'
     arguments:
-      - %assetic.node.bin%
-      - %hearsay_require_js.r.path%
-      - %hearsay_require_js.base_dir%
-      - %hearsay_require_js.declare_module_name%
+      - '%assetic.node.bin%'
+      - '%hearsay_require_js.r.path%'
+      - '%hearsay_require_js.base_dir%'
+      - '%hearsay_require_js.declare_module_name%'
     calls:
-      - [ addNodePath, [%assetic.node.bin%] ]
+      - [ addNodePath, ['%assetic.node.bin%'] ]
     tags:
       - { name: assetic.filter, alias: requirejs }

--- a/Tests/Assetic/Factory/Loader/ModuleFormulaLoaderTest.php
+++ b/Tests/Assetic/Factory/Loader/ModuleFormulaLoaderTest.php
@@ -12,12 +12,13 @@
 namespace Hearsay\RequireJSBundle\Tests\Assetic\Factory\Loader;
 
 use Hearsay\RequireJSBundle\Assetic\Factory\Loader\ModuleFormulaLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the module formula loader.
  * @author Kevin Montag <kevin@hearsay.it>
  */
-class ModuleFormulaLoaderTest extends \PHPUnit_Framework_TestCase
+class ModuleFormulaLoaderTest extends TestCase
 {
     public function testFormulaeLoaded()
     {
@@ -36,7 +37,7 @@ class ModuleFormulaLoaderTest extends \PHPUnit_Framework_TestCase
                 ->with($file2, array())
                 ->will($this->returnValue('other_file'));
 
-        $mapping = $this->getMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
+        $mapping = $this->createMock('Hearsay\RequireJSBundle\Configuration\NamespaceMappingInterface');
         $mapping->expects($this->at(0))
                 ->method('getModulePath')
                 ->with($file1)
@@ -46,7 +47,7 @@ class ModuleFormulaLoaderTest extends \PHPUnit_Framework_TestCase
                 ->with($file2)
                 ->will($this->returnValue('second/module'));
 
-        $resource = $this->getMock('Assetic\Factory\Resource\ResourceInterface');
+        $resource = $this->createMock('Assetic\Factory\Resource\ResourceInterface');
         $resource->expects($this->any())
                 ->method('getContent')
                 ->will($this->returnValue($file1 . "\nsome other\ntext\n" . $file2));

--- a/Tests/Assetic/Factory/Resource/FilenamesResourceTest.php
+++ b/Tests/Assetic/Factory/Resource/FilenamesResourceTest.php
@@ -12,12 +12,13 @@
 namespace Hearsay\RequireJSBundle\Tests\Assetic\Factory\Resource;
 
 use Hearsay\RequireJSBundle\Assetic\Factory\Resource\FilenamesResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the filename resource.
  * @author Kevin Montag <kevin@hearsay.it>
  */
-class FilenamesResourceTest extends \PHPUnit_Framework_TestCase
+class FilenamesResourceTest extends TestCase
 {
     public function testFilenamesRetrieved()
     {

--- a/Tests/Assetic/Filter/RJsFilterTest.php
+++ b/Tests/Assetic/Filter/RJsFilterTest.php
@@ -12,6 +12,7 @@
 namespace Hearsay\RequireJSBundle\Tests\Filter;
 
 use Assetic\Asset\FileAsset;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\ExecutableFinder;
 
 use Assetic\Asset\StringAsset;
@@ -22,7 +23,7 @@ use Hearsay\RequireJSBundle\Assetic\Filter\RJsFilter;
  * @author Kevin Montag <kevin@hearsay.it>
  * @author Igor Timoshenko <igor.timoshenko@i.ua>
  */
-class RJsFilterTest extends \PHPUnit_Framework_TestCase
+class RJsFilterTest extends TestCase
 {
     /**
      * @var string
@@ -110,7 +111,7 @@ require(['unknown/module'], function(module) {
 });
 JS;
 
-        $this->setExpectedException('Assetic\Exception\FilterException');
+        $this->expectException('Assetic\Exception\FilterException');
 
         $this->getStringAsset($javascript)->dump();
     }

--- a/Tests/Configuration/NamespaceMappingTest.php
+++ b/Tests/Configuration/NamespaceMappingTest.php
@@ -12,12 +12,13 @@
 namespace Hearsay\RequireJSBundle\Tests\Configuration;
 
 use Hearsay\RequireJSBundle\Configuration\NamespaceMapping;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the namespace mapping container.
  * @author Kevin Montag <kevin@hearsay.it>
  */
-class NamespaceMappingTest extends \PHPUnit_Framework_TestCase
+class NamespaceMappingTest extends TestCase
 {
     /**
      * @var NamespaceMapping
@@ -39,10 +40,7 @@ class NamespaceMappingTest extends \PHPUnit_Framework_TestCase
      */
     public function testNonExistentModulePathThrowsException()
     {
-        $this->setExpectedException(
-            'Hearsay\RequireJSBundle\Exception\PathNotFoundException',
-            ''
-        );
+        $this->expectException('Hearsay\RequireJSBundle\Exception\PathNotFoundException');
 
         $this->mapping->registerNamespace('dir', 'root');
     }

--- a/Tests/DependencyInjection/HearsayRequireJSExtensionTest.php
+++ b/Tests/DependencyInjection/HearsayRequireJSExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Hearsay\RequireJSBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 use Hearsay\RequireJSBundle\DependencyInjection\HearsayRequireJSExtension;
@@ -19,7 +20,7 @@ use Hearsay\RequireJSBundle\DependencyInjection\HearsayRequireJSExtension;
  * Unit tests for the bundle loader.
  * @author Kevin Montag <kevin@hearsay.it>
  */
-class HearsayRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
+class HearsayRequireJSExtensionTest extends TestCase
 {
     /**
      * @var HearsayRequireJSExtension
@@ -56,9 +57,8 @@ class HearsayRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
         foreach ($paths as $path) {
             $config['paths'][0] = $path;
 
-            $this->setExpectedException(
-                'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException',
-                ''
+            $this->expectException(
+                'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException'
             );
 
             $this->extension->load(array($config), $container);
@@ -85,9 +85,8 @@ class HearsayRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
 
         $container = $this->getContainerBuilder();
 
-        $this->setExpectedException(
-            'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException',
-            'The path should NOT include the ".js" file extension.'
+        $this->expectException(
+            'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException'
         );
 
         $this->extension->load(array($config), $container);
@@ -189,12 +188,12 @@ class HearsayRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
         // Check the Assetic resources
         foreach ($paths as $path) {
             /**
-             * @var $resource \Symfony\Component\DependencyInjection\DefinitionDecorator
+             * @var $resource \Symfony\Component\DependencyInjection\ChildDefinition
              */
             $resource = $container->getDefinition('hearsay_require_js.filenames_resource.' . md5($path));
 
             $this->assertInstanceOf(
-                'Symfony\Component\DependencyInjection\DefinitionDecorator',
+                'Symfony\Component\DependencyInjection\ChildDefinition',
                 $resource
             );
             $this->assertEquals(
@@ -330,7 +329,7 @@ class HearsayRequireJSExtensionTest extends \PHPUnit_Framework_TestCase
 
         $container = $this->getContainerBuilder();
 
-        $this->setExpectedException('InvalidArgumentException', 'Unrecognized bundle: "UnknownBundle"');
+        $this->expectException('InvalidArgumentException');
 
         $this->extension->load(array($config), $container);
     }

--- a/Tests/Templating/Helper/RequireJSHelperTest.php
+++ b/Tests/Templating/Helper/RequireJSHelperTest.php
@@ -12,12 +12,13 @@
 namespace Hearsay\RequireJSBundle\Tests\Templating\Helper;
 
 use Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the templating helper.
  * @author Kevin Montag <kevin@hearsay.it>
  */
-class RequireJSHelperTest extends \PHPUnit_Framework_TestCase
+class RequireJSHelperTest extends TestCase
 {
     /**
      * @covers Hearsay\RequireJSBundle\Templating\Helper\RequireJSHelper::initialize
@@ -94,7 +95,7 @@ class RequireJSHelperTest extends \PHPUnit_Framework_TestCase
      */
     private function getEngineMock($config = null, $main = null)
     {
-        $engine = $this->getMock('Symfony\Component\Templating\EngineInterface');
+        $engine = $this->createMock('Symfony\Component\Templating\EngineInterface');
         $engine->expects($this->once())
             ->method('render')
             ->with('template', array(

--- a/Tests/Twig/Extension/RequireJSExtensionTest.php
+++ b/Tests/Twig/Extension/RequireJSExtensionTest.php
@@ -11,15 +11,16 @@
 
 namespace Hearsay\RequireJSBundle\Tests\Twig\Extension;
 
+use Hearsay\RequireJSBundle\Configuration\ConfigurationBuilder;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\Scope;
 
 use Hearsay\RequireJSBundle\Twig\Extension\RequireJSExtension;
 
 /**
  * @author Igor Timoshenko <igor.timoshenko@i.ua>
  */
-class RequireJSExtensionTest extends \PHPUnit_Framework_TestCase
+class RequireJSExtensionTest extends TestCase
 {
     /**
      * @var Container
@@ -69,8 +70,18 @@ class RequireJSExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetGlobalsInActiveRequestScope()
     {
-        $this->container->addScope(new Scope('request'));
-        $this->container->enterScope('request');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+
+        $requestStack = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')
+            ->getMock();
+
+        $requestStack
+            ->expects($this->any())
+            ->method('getCurrentRequest')
+            ->willReturn($request);
+
+        $this->container->set('request_stack', $requestStack);
 
         $this->assertEquals(
             array('require_js' => array('config' => array())),

--- a/Twig/Extension/RequireJSExtension.php
+++ b/Twig/Extension/RequireJSExtension.php
@@ -52,12 +52,15 @@ class RequireJSExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'require_js_initialize' => new \Twig_Function_Method(
-                $this,
-                'initialize',
+            new \Twig_SimpleFunction(
+                'require_js_initialize',
+                array($this, 'initialize'),
                 array('is_safe' => array('html'))
             ),
-            'require_js_src'        => new \Twig_Function_Method($this, 'src'),
+            new \Twig_SimpleFunction(
+                'require_js_src',
+                array($this, 'src')
+            ),
         );
     }
 
@@ -66,7 +69,8 @@ class RequireJSExtension extends \Twig_Extension
      */
     public function getGlobals()
     {
-        if (!$this->container->isScopeActive('request')) {
+        if (!$this->container->has('request_stack') ||
+            !$this->container->get('request_stack')->getCurrentRequest()) {
             return array();
         }
 

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,14 @@
         "symfony/finder": ">=2.0",
         "symfony/yaml": ">=2.0",
         "kriswallsmith/assetic": ">= 1.0",
-        "symfony/framework-bundle": ">=2.0.9"
+        "symfony/translation": ">=2.0.9",
+        "symfony/framework-bundle": ">=2.0.9",
+        "symfony/templating": ">=2.0.9"
     },
     "require-dev": {
-        "twig/extensions": "v1.0.0",
-        "squizlabs/php_codesniffer": "1.*",
-        "phpunit/phpunit": "3.7.*"
+        "squizlabs/php_codesniffer": "^3.4",
+        "phpunit/phpunit": "^7.5",
+        "twig/extensions": "^1.5"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="Tests/bootstrap.php"
 >
     <testsuites>


### PR DESCRIPTION
I suggest merging this into a new `2.0` branch to ensure older applications don't break due to php / package versions being raised.